### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.1-rc-apache
 
 # PHP extensions
 ENV APCU_VERSION 5.1.5
@@ -39,10 +39,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+RUN php -r "copy('https://composer.github.io/installer.sig', 'installer.sig');" \
+    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
     && php composer-setup.php \
     && php -r "unlink('composer-setup.php');" \
+    && php -r "unlink('installer.sig');" \
     && mv composer.phar /usr/bin/composer \
     && composer global require "hirak/prestissimo:^0.3"
 


### PR DESCRIPTION
- [x] Migrate to PHP 7.1-rc
- [x] Update composer download (from https://github.com/api-platform/api-platform/pull/162)

I need to upgrade to PHP 7.1 (even in rc) to use `?string` syntax to allow `null` value in typehint