### PR TITLE
Fix MERCURE_JWT_SECRET env var which was not set in the Travis CI build

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -33,7 +33,7 @@ CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 
 ###> symfony/mercure-bundle ###
 MERCURE_PUBLISH_URL=http://mercure/hub
-MERCURE_JWT_SECRET=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM
+MERCURE_JWT_SECRET=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.qOwClmp3euDLhEQ2lOB0TLUHsobaAoe-nZ1iU3h_Eas
 ###< symfony/mercure-bundle ###
 
 MERCURE_SUBSCRIBE_URL=https://localhost:1338/hub

--- a/ci/before_deploy
+++ b/ci/before_deploy
@@ -17,8 +17,10 @@ fi
 # Generate random key & jwt for Mercure if not set
 if [[ -z $MERCURE_JWT_KEY ]]; then
     npm install --global "@clarketm/jwt-cli"
-    export MERCURE_JWT_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-    export MERCURE_JWT=$(jwt sign --noCopy '{"mercure": {"publish": ["*"]}}' $MERCURE_JWT_KEY)
+    MERCURE_JWT_KEY=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+    export MERCURE_JWT_KEY
+    MERCURE_JWT_SECRET=$(jwt sign --noCopy '{"mercure": {"publish": ["*"]}}' "$MERCURE_JWT_KEY")
+    export MERCURE_JWT_SECRET
 fi
 
 # Generate random database password if not set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     image: dunglas/mercure
     environment:
       # You should definitely change all these values in production
-      - JWT_KEY=!UnsecureChangeMe!
+      - JWT_KEY=!InsecureChangeMe! # You have to change MERCURE_JWT_SECRET in api/.env when you change this. You can put the old value of MERCURE_JWT_SECRET into the debugger on https://jwt.io/ and put the new value of JWT_KEY in the "secret" field to obtain the new encoded value for MERCURE_JWT_SECRET
       - ALLOW_ANONYMOUS=1
       - CORS_ALLOWED_ORIGINS=*
       - PUBLISH_ALLOWED_ORIGINS=http://localhost:1337,https://localhost:1338


### PR DESCRIPTION
Also add instructions for user on how to generate MERCURE_JWT_SECRET easily

"Unsecure" -> "Insecure"