### PR TITLE
feat: authorize localhost call to demo api

### DIFF
--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -16,7 +16,7 @@ php:
   env: prod
   debug: '0'
   secret: ""
-  corsAllowOrigin: "^https?://.*?\\.api-platform\\.com$"
+  corsAllowOrigin: "^https?://(.*?api-platform\\.com|localhost(?::[0-9]+)?)$"
   trustedHosts: "^.*\\.api\\-platform\\.com$"
   trustedProxies:
     - 103.21.244.0/22


### PR DESCRIPTION
To avoid CORS rejection when using client-generator we should enable this kind of origins

For info: regex battery test -> https://regex101.com/r/3CUlV8/2

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not sure of this (I can't install project ATM)
| License       | MIT