### PR TITLE
Fix Mercure CORS

### DIFF
--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -75,7 +75,7 @@ mercure:
   publishUrl: http://mercure/.well-known/mercure
   subscribeUrl: https://demo-mercure.api-platform.com/.well-known/mercure
   allowAnonymous: "1"
-  corsAllowedOrigins: "^https?://.*?\\.api-platform\\.com$"
+  corsAllowedOrigins: "^https?://.*\\.api-platform\\.com$"
   heartbeatInterval: "1s"
   service:
     type: NodePort

--- a/ci/deploy
+++ b/ci/deploy
@@ -80,7 +80,7 @@ helm upgrade --install --reset-values --force --namespace=$NAMESPACE --recreate-
     --set mercure.publishUrl="http://${RELEASE}-mercure/.well-known/mercure" \
     --set mercure.subscribeUrl="https://${MERCURE_ENTRYPOINT}/.well-known/mercure" \
     --set mercure.jwtKey=$MERCURE_JWT_KEY \
-    --set mercure.corsAllowedOrigins="https://${CLIENT_BUCKET}\,https://${ADMIN_BUCKET}" \
+    --set mercure.corsAllowedOrigins="https://${CLIENT_BUCKET} https://${ADMIN_BUCKET}" \
     --set mercure.domainFilters="{$DOMAIN}"
 
 # Reload fixtures: this is specific for this project!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - JWT_KEY=!InsecureChangeMe! # You have to change MERCURE_JWT_SECRET in api/.env when you change this. You can put the old value of MERCURE_JWT_SECRET into the debugger on https://jwt.io/ and put the new value of JWT_KEY in the "secret" field to obtain the new encoded value for MERCURE_JWT_SECRET
       - ALLOW_ANONYMOUS=1
       - CORS_ALLOWED_ORIGINS=*
-      - PUBLISH_ALLOWED_ORIGINS=http://localhost:1337,https://localhost:1338
+      - PUBLISH_ALLOWED_ORIGINS=http://localhost:1337 https://localhost:1338
       - DEMO=1
     ports:
       - "1337:80"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

[Since 0.10](https://github.com/dunglas/mercure/blob/master/docs/UPGRADE.md), Mercure changed its way of receiving the CORS: it now needs a space separated list instead of coma separated.