### PR TITLE
docker: force composer 1 for API component

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Install
 
     $ git clone https://github.com/api-platform/demo.git
     $ cd demo
-    $ docker-compose up
+    $ docker-compose up -d
 
-And go to https://localhost.
+And go to https://localhost
 
 Loading Fixtures
 ================
 
-    $ docker-compose exec php bin/console hautelook:fixtures:load --no-interaction
+    $ docker-compose exec php bin/console hautelook:fixtures:load --no-interaction --no-bundles

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -65,7 +65,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
 
 # Workaround to allow using PHPUnit 8 with Symfony 4.3
 ENV SYMFONY_PHPUNIT_VERSION=8.3


### PR DESCRIPTION
"api" compoent doesn't start with composer2 (latest), forcing dependency to composer 1 for now.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | NA.
| License       | MIT
| Doc PR        | NA.

