### PR TITLE
fix for #164 + regression tests

### DIFF
--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -50,6 +50,7 @@ class Review
     /**
      * @var int|null A rating
      *
+     * @Assert\NotBlank
      * @Assert\Range(min=0, max=5)
      * @ORM\Column(type="smallint")
      * @Groups({"review:read", "review:write"})

--- a/api/tests/ReviewsTest.php
+++ b/api/tests/ReviewsTest.php
@@ -7,13 +7,16 @@ namespace App\Tests;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client;
 use App\Entity\Book;
+use App\Entity\Review;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ReviewsTest extends ApiTestCase
 {
     use RefreshDatabaseTrait;
 
     private Client $client;
+    private const ISBN = '9786644879585';
 
     protected function setup(): void
     {
@@ -22,15 +25,112 @@ final class ReviewsTest extends ApiTestCase
 
     public function testFilterReviewsByBook(): void
     {
-        $iri = $this->findIriBy(Book::class, ['isbn' => '9786644879585']);
+        $iri = $this->findIriBy(Book::class, ['isbn' => self::ISBN]);
         $response = $this->client->request('GET', "/reviews?book=$iri");
         self::assertCount(2, $response->toArray()['hydra:member']);
     }
 
     public function testBookSubresource(): void
     {
-        $iri = $this->findIriBy(Book::class, ['isbn' => '9786644879585']);
+        $iri = $this->findIriBy(Book::class, ['isbn' => self::ISBN]);
         $response = $this->client->request('GET', "$iri/reviews");
         self::assertCount(2, $response->toArray()['hydra:member']);
+    }
+
+    public function testCreateInvalidReviewWithInvalidBody(): void
+    {
+        $iri = $this->findIriBy(Book::class, ['isbn' => self::ISBN]);
+        $this->client->request('POST', '/reviews', ['json' => [
+            'body' => '',
+            'rating' => 3,
+            'book' => $iri,
+            'author' => null,
+            'publicationDate' => null,
+        ]]);
+        self::assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        self::assertJsonContains([
+            '@context' => '/contexts/ConstraintViolationList',
+            '@type' => 'ConstraintViolationList',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => 'body: This value should not be blank.',
+        ]);
+        self::assertMatchesResourceItemJsonSchema(Review::class);
+    }
+
+    /**
+     * @see https://github.com/api-platform/demo/issues/164
+     */
+    public function testCreateInvalidReviewWithoutRating(): void
+    {
+        $iri = $this->findIriBy(Book::class, ['isbn' => self::ISBN]);
+        $this->client->request('POST', '/reviews', ['json' => [
+            'body' => 'bonjour',
+            //'rating' => '', // missing rating
+            'book' => $iri,
+            'author' => 'COil',
+            'publicationDate' => null,
+        ]]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        self::assertJsonContains([
+            '@context' => '/contexts/ConstraintViolationList',
+            '@type' => 'ConstraintViolationList',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => 'rating: This value should not be blank.',
+        ]);
+    }
+
+    public function testCreateInvalidReviewWithInvalidRating(): void
+    {
+        $iri = $this->findIriBy(Book::class, ['isbn' => self::ISBN]);
+        $this->client->request('POST', '/reviews', ['json' => [
+            'body' => 'bonjour',
+            'rating' => 6,
+            'book' => $iri,
+            'author' => 'COil',
+            'publicationDate' => null,
+        ]]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        self::assertJsonContains([
+            '@context' => '/contexts/ConstraintViolationList',
+            '@type' => 'ConstraintViolationList',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => 'rating: This value should be between 0 and 5.',
+        ]);
+    }
+
+    public function testCreateInvalidReviewWithInvalidBook(): void
+    {
+        $this->client->request('POST', '/reviews', ['json' => [
+            'body' => '',
+            'rating' => 0,
+            'book' => null,
+            'author' => '',
+            'publicationDate' => null,
+        ]]);
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        self::assertJsonContains([
+            '@context' => '/contexts/Error',
+            '@type' => 'hydra:Error',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => 'Expected IRI or nested document for attribute "book", "NULL" given.',
+        ]);
+
+        $this->client->request('POST', '/reviews', ['json' => [
+            'body' => '',
+            'rating' => 0,
+            'book' => '/invalid/book_iri',
+            'author' => '',
+            'publicationDate' => null,
+        ]]);
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        self::assertJsonContains([
+            '@context' => '/contexts/Error',
+            '@type' => 'hydra:Error',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => 'Invalid IRI "/invalid/book_iri".',
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? no
| Tickets       | fixes #164 
| License       | MIT
| Doc PR        | tests added

When creating a review without sending the "rating" parameter, the application raises an error 500 as a review row is being inserted without rating which is a mandatory field.