### PR TITLE
helm: replaced deprecated repo + updated deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
         run: |-
           helm repo add bitnami https://charts.bitnami.com/bitnami/
           helm repo add blackfire https://ribeiroplinio.github.io/helm-chart/
-          helm repo add kubernetes https://charts.helm.sh/stable/
+          helm repo add stable https://charts.helm.sh/stable/
           helm dependency build ./api/helm/api
 
       - name: Install API

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
         run: |-
           helm repo add bitnami https://charts.bitnami.com/bitnami/
           helm repo add blackfire https://ribeiroplinio.github.io/helm-chart/
-          helm repo add kubernetes https://kubernetes-charts.storage.googleapis.com/
+          helm repo add kubernetes https://charts.helm.sh/stable/
           helm dependency build ./api/helm/api
 
       - name: Install API

--- a/api/helm/api/Chart.lock
+++ b/api/helm/api/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 9.8.4
+  version: 9.8.11
 - name: mercure
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 4.0.1
 - name: blackfire
   repository: https://ribeiroplinio.github.io/helm-chart/
@@ -11,5 +11,5 @@ dependencies:
 - name: external-dns
   repository: https://charts.bitnami.com/bitnami/
   version: 3.4.9
-digest: sha256:42fa86f8ead631d56f45318cf1040a3f7fc8d40aed3d2fb1d99318894f03b01a
-generated: "2020-10-21T11:44:41.714358373+02:00"
+digest: sha256:aed7390f27df4e48014e99f3e5a7bca888bf9ef8148d8ac9b86ee962352d93e9
+generated: "2020-11-10T12:51:43.686828+01:00"

--- a/api/helm/api/Chart.yaml
+++ b/api/helm/api/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
       condition: postgresql.enabled
     - name: mercure
       version: ~4.0.0
-      repository: https://kubernetes-charts.storage.googleapis.com/
+      repository: https://charts.helm.sh/stable/
       condition: mercure.enabled
     - name: blackfire
       version: ~0.3.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | fixes #167 
| License       | MIT
| Doc PR        | NA.

This is to fix the following error:

```
`Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
Error: Process completed with exit code 1. `
``` 