### PR TITLE
swagger: example to document a legacy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ What can I find in this demo?
 
 This demo application contains several things you may be interested.   
 
-API testing
+API Testing
 -----------
 
 All entities used in this project are thoroughly tested. Each test class extends
@@ -46,7 +46,7 @@ Overriding the OpenAPI Specification
 
 This example shows how to document an API endpoint that isn't handled by API Platform.
 This "legacy" endpoint is listed and testable like the other ones thanks to the
-Swagger interface. 
+Swagger interface.
  
 * [Overriding the OpenAPI Specification documentation](https://api-platform.com/docs/core/swagger/#overriding-the-openapi-specification)
 * [Code in api/src/Swagger/SwaggerDecorator.php](api/src/Swagger/SwaggerDecorator.php)

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ What can I find in this demo?
 
 This demo application contains several things you may be interested.   
 
-Tests
------
+API testing
+-----------
 
 All entities used in this project are thoroughly tested. Each test class extends
 the `ApiTestCase`, which contains specific API assertions. It will make your tests
-much more straightforward than using the standard `WebTestCase` provided by Symfony. 
+much more straightforward than using the standard `WebTestCase` provided by Symfony.
 
 * [Tests documentation](https://api-platform.com/docs/core/testing/)
 * [Code in api/tests/](api/tests)
@@ -35,11 +35,21 @@ much more straightforward than using the standard `WebTestCase` provided by Symf
 Custom data provider
 --------------------
 
-This example shows how to expose a CSV file as a standard API Platform endpoint
-It also shows how to make this endpoint paginated.
+This example shows how to expose a CSV file as a standard API Platform endpoint.
+It also shows how to make this endpoint paginated with an extension.
 
 * [Data providers documentation](https://api-platform.com/docs/core/data-providers/)
 * [Code in api/src/DataProvider](api/src/DataProvider)
+
+Overriding the OpenAPI Specification
+------------------------------------
+
+This example shows how to document an API endpoint that isn't handled by API Platform.
+This "legacy" endpoint is listed and testable like the other ones thanks to the
+Swagger interface. 
+ 
+* [Overriding the OpenAPI Specification documentation](https://api-platform.com/docs/core/swagger/#overriding-the-openapi-specification)
+* [Code in api/src/Swagger/SwaggerDecorator.php](api/src/Swagger/SwaggerDecorator.php)
 
 Contributing
 ============

--- a/api/composer.json
+++ b/api/composer.json
@@ -90,6 +90,8 @@
             "bin/phpunit"
         ],
         "tests": [
+            "@phpunit tests/Controller/LegacyApiControllerTest.php",
+            "@phpunit tests/Controller/SwaggerTest.php",
             "@phpunit tests/Entity/TopBooksTest.php",
             "@phpunit tests/TopBooksTest.php",
             "@phpunit tests/BooksTest.php",

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -45,5 +45,3 @@ services:
     # Swagger doc customisation
     App\Swagger\SwaggerDecorator:
         decorates: 'api_platform.swagger.normalizer.api_gateway'
-        #arguments: ['@api_platform.swagger.normalizer.api_gateway.inner' ]
-        #autoconfigure: false

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -41,3 +41,9 @@ services:
         decorates: App\Repository\TopBook\TopBookDataRepository
 
     App\Repository\TopBook\TopBookDataInterface: '@App\Repository\TopBook\TopBookDataRepository'
+
+    # Swagger doc customisation
+    App\Swagger\SwaggerDecorator:
+        decorates: 'api_platform.swagger.normalizer.api_gateway'
+        arguments: ['@api_platform.swagger.normalizer.api_gateway.inner' ]
+        autoconfigure: false

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -45,3 +45,4 @@ services:
     # Swagger doc customisation
     App\Swagger\SwaggerDecorator:
         decorates: 'api_platform.swagger.normalizer.api_gateway'
+        autoconfigure: false

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -45,5 +45,5 @@ services:
     # Swagger doc customisation
     App\Swagger\SwaggerDecorator:
         decorates: 'api_platform.swagger.normalizer.api_gateway'
-        arguments: ['@api_platform.swagger.normalizer.api_gateway.inner' ]
-        autoconfigure: false
+        #arguments: ['@api_platform.swagger.normalizer.api_gateway.inner' ]
+        #autoconfigure: false

--- a/api/src/Controller/LegacyApiController.php
+++ b/api/src/Controller/LegacyApiController.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Swagger\SwaggerDecorator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * This is a dummy controller providing a fake API endpoint. This route is availlable
+ * in the Swagger interface thanks to the SwaggerDecorator service.
+ *
+ * @see SwaggerDecorator
+ */
 final class LegacyApiController extends AbstractController
 {
     /**
-     * @Route("/stats", name="api_book_stats")
+     * @Route("/stats")
      */
-    public function stats(): Response
+    public function __invoke(): Response
     {
         return $this->json([
             'books_count' => 1000,

--- a/api/src/Controller/LegacyApiController.php
+++ b/api/src/Controller/LegacyApiController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * This is a dummy controller providing a fake API endpoint. This route is availlable
+ * This is a dummy controller providing a fake API endpoint. This route is available
  * in the Swagger interface thanks to the SwaggerDecorator service.
  *
  * @see SwaggerDecorator

--- a/api/src/Controller/LegacyApiController.php
+++ b/api/src/Controller/LegacyApiController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LegacyApiController extends AbstractController
+{
+    /**
+     * @Route("/stats", name="api_book_stats")
+     */
+    public function stats(): Response
+    {
+        return $this->json([
+            'books_count' => 1000,
+            'topbooks_count' => 100,
+        ]);
+    }
+}

--- a/api/src/Controller/LegacyApiController.php
+++ b/api/src/Controller/LegacyApiController.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class LegacyApiController extends AbstractController
+final class LegacyApiController extends AbstractController
 {
     /**
      * @Route("/stats", name="api_book_stats")

--- a/api/src/Swagger/SwaggerDecorator.php
+++ b/api/src/Swagger/SwaggerDecorator.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Swagger;
 
+use App\Controller\LegacyApiController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
+/**
+ * Adds the Swagger documentation for the LegacyApiController.
+ *
+ * @see LegacyApiController
+ */
 final class SwaggerDecorator implements NormalizerInterface
 {
     private NormalizerInterface $decorated;
@@ -18,7 +23,7 @@ final class SwaggerDecorator implements NormalizerInterface
     }
 
     /**
-     * @throws ExceptionInterface
+     * {@inheritdoc}
      */
     public function normalize($object, string $format = null, array $context = [])
     {
@@ -54,6 +59,9 @@ final class SwaggerDecorator implements NormalizerInterface
         return $docs;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function supportsNormalization($data, string $format = null): bool
     {
         return $this->decorated->supportsNormalization($data, $format);

--- a/api/src/Swagger/SwaggerDecorator.php
+++ b/api/src/Swagger/SwaggerDecorator.php
@@ -28,7 +28,7 @@ final class SwaggerDecorator implements NormalizerInterface
     public function normalize($object, string $format = null, array $context = [])
     {
         $docs = $this->decorated->normalize($object, $format, $context);
-        $statsEnpoint = [
+        $statsEndpoint = [
             'summary' => 'Retrieves the number of books and top books (legacy endpoint).',
             'tags' => ['Stats'],
             'responses' => [
@@ -54,7 +54,7 @@ final class SwaggerDecorator implements NormalizerInterface
             ],
         ];
 
-        $docs['paths']['/stats']['get'] = $statsEnpoint;
+        $docs['paths']['/stats']['get'] = $statsEndpoint;
 
         return $docs;
     }

--- a/api/src/Swagger/SwaggerDecorator.php
+++ b/api/src/Swagger/SwaggerDecorator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Swagger;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class SwaggerDecorator implements NormalizerInterface
+{
+    private NormalizerInterface $decorated;
+
+    public function __construct(NormalizerInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        $docs = $this->decorated->normalize($object, $format, $context);
+        $statsEnpoint = [
+            'summary' => 'Retrieves the number of books and top books (legacy endpoint).',
+            'tags' => ['Stats'],
+            'responses' => [
+                Response::HTTP_OK => [
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'books_count' => [
+                                        'type' => 'integer',
+                                        'example' => 997,
+                                    ],
+                                    'topbooks_count' => [
+                                        'type' => 'integer',
+                                        'example' => 101,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $docs['paths']['/stats']['get'] = $statsEnpoint;
+
+        return $docs;
+    }
+
+    public function supportsNormalization($data, string $format = null): bool
+    {
+        return $this->decorated->supportsNormalization($data, $format);
+    }
+}

--- a/api/tests/Controller/LegacyApiControllerTest.php
+++ b/api/tests/Controller/LegacyApiControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client;
+use App\Controller\LegacyApiController;
+
+/**
+ * @see LegacyApiController
+ */
+class LegacyApiControllerTest extends ApiTestCase
+{
+    private Client $client;
+
+    protected function setup(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    /**
+     * @covers LegacyApiController::stats()
+     */
+    public function testStats(): void
+    {
+        $this->client->request('GET', '/stats');
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+        self::assertJsonEquals([
+            'books_count'    => 1000,
+            'topbooks_count' => 100,
+        ]);
+    }
+}

--- a/api/tests/Controller/LegacyApiControllerTest.php
+++ b/api/tests/Controller/LegacyApiControllerTest.php
@@ -21,7 +21,7 @@ class LegacyApiControllerTest extends ApiTestCase
     }
 
     /**
-     * @covers LegacyApiController::stats()
+     * @see LegacyApiController::stats()
      */
     public function testStats(): void
     {
@@ -29,7 +29,7 @@ class LegacyApiControllerTest extends ApiTestCase
         self::assertResponseIsSuccessful();
         self::assertResponseHeaderSame('content-type', 'application/json');
         self::assertJsonEquals([
-            'books_count'    => 1000,
+            'books_count' => 1000,
             'topbooks_count' => 100,
         ]);
     }

--- a/api/tests/Controller/LegacyApiControllerTest.php
+++ b/api/tests/Controller/LegacyApiControllerTest.php
@@ -11,7 +11,7 @@ use App\Controller\LegacyApiController;
 /**
  * @see LegacyApiController
  */
-class LegacyApiControllerTest extends ApiTestCase
+final class LegacyApiControllerTest extends ApiTestCase
 {
     private Client $client;
 

--- a/api/tests/Controller/SwaggerTest.php
+++ b/api/tests/Controller/SwaggerTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Controller;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class SwaggerTest extends WebTestCase
+final class SwaggerTest extends WebTestCase
 {
     private KernelBrowser $client;
 

--- a/api/tests/Controller/SwaggerTest.php
+++ b/api/tests/Controller/SwaggerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class SwaggerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    protected function setup(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testStats(): void
+    {
+        $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Stats', (string) $this->client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | NA.
| License       | MIT
| Doc PR        | todo once this PR is merged.

This is a simple example showing how to extend the OpenAPI spec is order to document a legacy endpoint.