### PR TITLE
Update README.md Swagger link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This example shows how to document an API endpoint that isn't handled by API Pla
 This "legacy" endpoint is listed and testable like the other ones thanks to the
 Swagger interface.
  
-* [Overriding the OpenAPI Specification documentation](https://api-platform.com/docs/core/swagger/#overriding-the-openapi-specification)
+* [Overriding the OpenAPI Specification documentation](https://api-platform.com/docs/core/openapi/#overriding-the-openapi-specification)
 * [Code in api/src/Swagger/SwaggerDecorator.php](api/src/Swagger/SwaggerDecorator.php)
 
 Contributing


### PR DESCRIPTION
Fixing the link "https://api-platform.com/docs/core/swagger/" that leads to a 404
