### PR TITLE
ci: reduce default postgresql resources requests

### DIFF
--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -64,6 +64,10 @@ postgresql:
   image:
     repository: bitnami/postgresql
     tag: 13
+  resources:
+    requests:
+      memory: 50Mi
+      cpu: 50m
 
 external-dns:
   enabled: true


### PR DESCRIPTION
Reduce default PostgreSQL dependency resources requests, to use less nodes on Kubernetes cluster