### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           # https://github.com/google-github-actions/setup-gcloud/issues/128
           version: '290.0.1'
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           # https://github.com/google-github-actions/setup-gcloud/issues/128
           version: '290.0.1'
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           # https://github.com/google-github-actions/setup-gcloud/issues/128
           version: '290.0.1'
@@ -177,7 +177,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           # https://github.com/google-github-actions/setup-gcloud/issues/128
           version: '290.0.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Jest
         run: docker-compose exec -T pwa yarn test --ci --passWithNoTests
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
       - name: Lint Helm
         run: helm lint ./helm/api-platform/

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           # https://github.com/google-github-actions/setup-gcloud/issues/128
           version: '290.0.1'


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.