### PR TITLE
Fix pagination in the OpenAPI admin

### DIFF
--- a/pwa/components/admin/Admin.tsx
+++ b/pwa/components/admin/Admin.tsx
@@ -121,6 +121,7 @@ const AdminUI = () => {
     </HydraAdmin>
   ) : (
     <OpenApiAdmin
+      dataProvider={dataProvider(setRedirectToLogin)}
       authProvider={authProvider}
       entrypoint={window.origin}
       docEntrypoint={`${window.origin}/docs.json`}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | #315 
| License       | MIT

Fix the problem of pagination in open api admin
The problem was that even if we click to the pagination button in open api admin the data in the list never change and just stay the same.

To fix the problem, I add the dataProvider to the OpenApiAdmin component

For security issues please email contact@les-tilleuls.coop.