### PR TITLE
fix: caddy version 2.6 to 2.7 to fix the CI

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -95,9 +95,10 @@ RUN set -eux; \
 RUN rm -f .env.local.php
 
 # Build Caddy with the Mercure and Vulcain modules
-FROM caddy:2-builder-alpine AS app_caddy_builder
+# Temporary fix for https://github.com/dunglas/mercure/issues/770
+FROM caddy:2.7-builder-alpine AS app_caddy_builder
 
-RUN xcaddy build \
+RUN xcaddy build v2.6.4 \
 	--with github.com/dunglas/mercure/caddy \
 	--with github.com/dunglas/vulcain/caddy
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fix the CI with changement of the version of caddy (2.6.4 => 2.7)

Cf. https://github.com/dunglas/mercure/issues/770#issuecomment-1558154310

Fix from https://github.com/dunglas/symfony-docker/pull/407/files