### PR TITLE
test: test that an options request on root endpoint is successfull

### DIFF
--- a/api/tests/Api/RootTest.php
+++ b/api/tests/Api/RootTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class RootTest extends ApiTestCase
+{
+    use ResetDatabase;
+
+    private Client $client;
+
+    protected function setup(): void
+    {
+        $this->client = self::createClient();
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     *
+     * @test
+     */
+    public function optionsWhenNotLoggedIn(): void
+    {
+        $this->client->request(
+            'OPTIONS',
+            '/',
+            [
+                'headers' => [
+                    'Origin' => 'http://localhost:3000',
+                    'Access-Control-Request-Method' => 'GET',
+                    'Access-Control-Request-Headers' => 'Origin, Content-Type, Accept, Authorization',
+                ],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/api-platform/core/issues/6455 It is more or less the same test as in
https://github.com/ecamp/ecamp3/blob/3cd279fd1c1367287ea989f38f7238f93026e4b4/api/tests/Api/RootTest.php

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        |

This is a test that tests the OPTIONS request on the root endpoint.
I did not know where to add this in https://github.com/api-platform/core
So i added the test here that a possible issue is detected a little earlier.
