### PR TITLE
fix:  decode OpenLibrary author response before accessing fields

### DIFF
--- a/api/src/BookRepository/OpenLibraryBookRepository.php
+++ b/api/src/BookRepository/OpenLibraryBookRepository.php
@@ -36,7 +36,8 @@ final readonly class OpenLibraryBookRepository implements RestrictedBookReposito
 
         $book->author = null;
         if (isset($data['authors'][0]['key'])) {
-            $author = $this->openLibraryClient->request('GET', $data['authors'][0]['key'] . '.json', $options);
+            $authorResponse = $this->openLibraryClient->request('GET', $data['authors'][0]['key'] . '.json', $options);
+            $author = $this->decoder->decode($authorResponse->getContent(), 'json');
             if (isset($author['name'])) {
                 $book->author = $author['name'];
             }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Tickets       | N/A <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

The author response from the OpenLibrary API was being treated as an array, but HttpClientInterface::request() returns a ResponseInterface. This caused a fatal error when trying to access `$author['name']`.

Now the response content is properly decoded before accessing the 'name' field.
