### PR TITLE
fix: set OIDC_UPSTREAM for proxy'ing keycloak

### DIFF
--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: :80
             - name: PWA_UPSTREAM
               value: {{ include "api-platform.fullname" . }}-pwa:3000
+            - name: OIDC_UPSTREAM
+              value: {{ include "api-platform.fullname" . }}-keycloak
             - name: MERCURE_PUBLISHER_JWT_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Seems like it was missing, causing caddy to fail at proxy'ing keycloak. Fixes #546.

| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Tickets       | Closes #546  <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
