### PR TITLE
Fix postgresql crashlooping

### DIFF
--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -83,7 +83,7 @@ postgresql:
       size: 1Gi
     pullPolicy: Always
     image:
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
       tag: 16
     resources:
       requests:


### PR DESCRIPTION
was using deprecated bitnami image registry. replaced temporarly with bitnamilegacy
