### PR TITLE
fix: container registry definition

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Versions
-FROM dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
+FROM docker.io/dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
 
 
 # The different stages of this Dockerfile are meant to be built into separate images

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,7 +54,7 @@ services:
 
 ###> doctrine/doctrine-bundle ###
   database:
-    image: postgres:${POSTGRES_VERSION:-16}-alpine
+    image: docker.io/postgres:${POSTGRES_VERSION:-16}-alpine
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-app}
       # You should definitely change the password in production
@@ -76,7 +76,7 @@ services:
 ###< symfony/mercure-bundle ###
 
   keycloak-database:
-    image: postgres:${KEYCLOAK_POSTGRES_VERSION:-16}-alpine
+    image: docker.io/postgres:${KEYCLOAK_POSTGRES_VERSION:-16}-alpine
     environment:
       POSTGRES_DB: ${KEYCLOAK_POSTGRES_DB:-keycloak}
       # You should definitely change the password in production

--- a/helm/api-platform/keycloak/Dockerfile
+++ b/helm/api-platform/keycloak/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Versions
-FROM bitnamilegacy/keycloak:26-debian-12 AS keycloak_upstream
+FROM docker.io/bitnamilegacy/keycloak:26-debian-12 AS keycloak_upstream
 
 
 # The different stages of this Dockerfile are meant to be built into separate images

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -2,7 +2,7 @@
 
 
 # Versions
-FROM node:lts AS node_upstream
+FROM docker.io/node:lts AS node_upstream
 
 
 # Base stage for dev and build


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current
| License       | MIT

We should always write the full url of upstream images instead of using the systems default registry (mostly configured as `docker.io`).

This solves conflicts with podman, which does not have any fallbacks defined per default (much cleaner in my opinion).