### PR TITLE
fix: remove `--link` for compatibility (podman)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -47,9 +47,9 @@ RUN set -eux; \
 ###< doctrine/doctrine-bundle ###
 ###< recipes ###
 
-COPY --link frankenphp/conf.d/app.ini $PHP_INI_DIR/conf.d/
-COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
-COPY --link frankenphp/Caddyfile /etc/caddy/Caddyfile
+COPY frankenphp/conf.d/app.ini $PHP_INI_DIR/conf.d/
+COPY --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+COPY frankenphp/Caddyfile /etc/caddy/Caddyfile
 
 ENTRYPOINT ["docker-entrypoint"]
 
@@ -69,7 +69,7 @@ RUN set -eux; \
 		xdebug \
 	;
 
-COPY --link frankenphp/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
+COPY frankenphp/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
 CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 
@@ -81,16 +81,16 @@ ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-COPY --link frankenphp/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
-COPY --link frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
+COPY frankenphp/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
+COPY frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
 
 # prevent the reinstallation of vendors at every changes in the source code
-COPY --link composer.* symfony.* ./
+COPY composer.* symfony.* ./
 RUN set -eux; \
 	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
 
 # copy sources
-COPY --link . ./
+COPY . ./
 RUN rm -Rf frankenphp/
 
 RUN set -eux; \

--- a/helm/api-platform/keycloak/Dockerfile
+++ b/helm/api-platform/keycloak/Dockerfile
@@ -15,5 +15,5 @@ FROM bitnamilegacy/keycloak:26-debian-12 AS keycloak_upstream
 # Keycloak image
 FROM keycloak_upstream AS keycloak
 
-COPY --link themes/api-platform-demo /opt/bitnami/keycloak/themes/api-platform-demo
-COPY --link providers/owner-policy.jar /opt/bitnami/keycloak/providers/owner-policy.jar
+COPY themes/api-platform-demo /opt/bitnami/keycloak/themes/api-platform-demo
+COPY providers/owner-policy.jar /opt/bitnami/keycloak/providers/owner-policy.jar

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -33,10 +33,10 @@ CMD ["sh", "-c", "pnpm install; pnpm dev"]
 
 FROM base AS builder
 
-COPY --link pnpm-lock.yaml ./
+COPY pnpm-lock.yaml ./
 RUN pnpm fetch --prod
 
-COPY --link . .
+COPY . .
 
 ARG AUTH_SECRET
 # https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser
@@ -58,7 +58,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN addgroup --system --gid 1001 nodejs; \
 	adduser --system --uid 1001 nextjs
 
-COPY --from=builder --link /srv/app/public ./public
+COPY --from=builder /srv/app/public ./public
 
 # Set the correct permission for prerender cache
 RUN mkdir .next; \
@@ -66,8 +66,8 @@ RUN mkdir .next; \
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /srv/app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /srv/app/.next/static ./.next/static
+COPY --from=builder --chown=1001:1001 /srv/app/.next/standalone ./
+COPY --from=builder --chown=1001:1001 /srv/app/.next/static ./.next/static
 
 USER nextjs
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current
| License       | MIT

Currently podman (especially buildah) does not support the `--link` flag in `COPY` command. Seems already fixed in upstream, but not reached most stable distros (e.g. ubuntu 25.10, podman 5.4, buildah 1.39.x), see also:
https://github.com/containers/buildah/issues/4325 (added to buildah 1.41.0 -> podman 5.6)

If u prefer using the `--link` flag for performance reasons, instead of a bit more temporary compatibility with other engines, just close this PR. Time will solve it anyway... :-)