### PR TITLE
chore: fix link from API to PWA

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -5,7 +5,7 @@ api_platform:
         This is a demo application of the [API Platform](https://api-platform.com) framework.
         [Its source code](https://github.com/api-platform/demo) includes various examples, check it out!
         You may also be interested by [the GraphQL entrypoint](/graphql).
-        [A PWA](/) and [an admin](/admin) are consuming this API.
+        [A PWA](/books) and [an admin](/admin) are consuming this API.
     # Mercure integration, remove if unwanted
     mercure:
         include_type: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | .
| License       | MIT
| Doc PR        | .

The PWA is available on the https://localhost/books URL.