### PR TITLE
fix: error from Caddy

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -30,7 +30,9 @@
 
 	mercure {
 		# Transport to use (default to Bolt)
-		transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
+		transport bolt {
+			path /data/mercure.db
+		}
 		# Publisher JWT key
 		publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
 		# Subscriber JWT key


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | .
| License       | MIT
| Doc PR        | .

It was generating one error per second:

```
php-1                | 2026/01/28 17:04:20.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:21.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:22.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:23.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:24.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:25.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:26.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:27.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:28.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
php-1                | 2026/01/28 17:04:29.778  ERROR   Setting the "transport_url" directive is not available anymore, use the "transport" directive instead
```

Changing this remove these repeated errors but show one error once:

```
php-1                | 2026/01/28 17:04:30.778  ERROR   watcher unable to load latest config    {"config_file": "/etc/caddy/Caddyfile", "error": "adapting config using caddyfile: parsing caddyfile tokens for 'mercure': getting module named 'http.handlers.mercure.bolt:///data/mercure.db': module not registered: http.handlers.mercure.bolt:///data/mercure.db, at /etc/caddy/Caddyfile:31"}
```