### PR TITLE
fix: use PATCH instead of PUT

### DIFF
--- a/api/src/Entity/Book.php
+++ b/api/src/Entity/Book.php
@@ -13,8 +13,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use App\Enum\BookCondition;
 use App\Repository\BookRepository;
@@ -54,8 +54,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(
             uriTemplate: '/admin/books/{id}{._format}'
         ),
-        // https://github.com/api-platform/admin/issues/370
-        new Put(
+        new Patch(
             uriTemplate: '/admin/books/{id}{._format}',
             processor: BookPersistProcessor::class
         ),

--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -13,9 +13,9 @@ use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\NotExposed;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\State\CreateProvider;
+use ApiPlatform\State\SerializerContextBuilderInterface;
 use App\Repository\ReviewRepository;
 use App\Security\Voter\OidcTokenPermissionVoter;
 use App\Serializer\IriTransformerNormalizer;
@@ -54,8 +54,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(
             uriTemplate: '/admin/reviews/{id}{._format}'
         ),
-        // https://github.com/api-platform/admin/issues/370
-        new Put(
+        new Patch(
             uriTemplate: '/admin/reviews/{id}{._format}',
             processor: ReviewPersistProcessor::class
         ),
@@ -74,6 +73,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     denormalizationContext: [
         AbstractNormalizer::GROUPS => ['Review:write', 'Review:write:admin'],
+        SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE => true,
     ],
     collectDenormalizationErrors: true,
     security: 'is_granted("OIDC_ADMIN")',

--- a/api/src/State/Processor/ReviewPersistProcessor.php
+++ b/api/src/State/Processor/ReviewPersistProcessor.php
@@ -7,7 +7,6 @@ namespace App\State\Processor;
 use ApiPlatform\Doctrine\Common\State\PersistProcessor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Review;
 use App\Security\Http\Protection\ResourceHandlerInterface;
@@ -42,13 +41,6 @@ final readonly class ReviewPersistProcessor implements ProcessorInterface
             /** @phpstan-ignore-next-line */
             $data->user = $this->security->getUser();
             $data->publishedAt = $this->clock->now();
-        }
-
-        // standard PUT
-        // todo find why $data lost properties unauthorized from deserialization
-        if ($operation instanceof Put && isset($context['previous_data'])) {
-            $data->user = $context['previous_data']->user;
-            $data->publishedAt = $context['previous_data']->publishedAt;
         }
 
         // save entity

--- a/api/tests/Api/Admin/BookTest.php
+++ b/api/tests/Api/Admin/BookTest.php
@@ -15,6 +15,7 @@ use App\Tests\Api\Admin\Trait\UsersDataProviderTrait;
 use App\Tests\Api\Security\TokenGenerator;
 use App\Tests\Api\Trait\SerializerTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mercure\Update;
@@ -363,8 +364,8 @@ final class BookTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('apiCall')]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('apiCall')]
+    #[Group('mercure')]
     public function asAdminUserICanCreateABook(): void
     {
         $token = self::getContainer()->get(TokenGenerator::class)->generateToken([
@@ -424,13 +425,13 @@ final class BookTest extends ApiTestCase
             $options['auth_bearer'] = $token;
         }
 
-        $this->client->request('PUT', '/admin/books/' . $book->getId(), $options + [
+        $this->client->request('PATCH', '/admin/books/' . $book->getId(), $options + [
             'json' => [
                 'book' => 'https://gutendex.com/books/31547.json',
                 'condition' => BookCondition::NewCondition->value,
             ],
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -454,13 +455,13 @@ final class BookTest extends ApiTestCase
             'email' => UserFactory::createOneAdmin()->email,
         ]);
 
-        $this->client->request('PUT', '/admin/books/invalid', [
+        $this->client->request('PATCH', '/admin/books/invalid', [
             'auth_bearer' => $token,
             'json' => [
                 'condition' => BookCondition::DamagedCondition->value,
             ],
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -478,11 +479,11 @@ final class BookTest extends ApiTestCase
             'email' => UserFactory::createOneAdmin()->email,
         ]);
 
-        $this->client->request('PUT', '/admin/books/' . $book->getId(), [
+        $this->client->request('PATCH', '/admin/books/' . $book->getId(), [
             'auth_bearer' => $token,
             'json' => $data,
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -494,12 +495,13 @@ final class BookTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('apiCall')]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('apiCall')]
+    #[Group('mercure')]
     public function asAdminUserICanUpdateABook(): void
     {
         $book = BookFactory::createOne([
             'book' => 'https://gutendex.com/books/31547.json',
+            'condition' => BookCondition::UsedCondition,
         ]);
         self::getMercureHub()->reset();
 
@@ -507,16 +509,13 @@ final class BookTest extends ApiTestCase
             'email' => UserFactory::createOneAdmin()->email,
         ]);
 
-        $response = $this->client->request('PUT', '/admin/books/' . $book->getId(), [
+        $response = $this->client->request('PATCH', '/admin/books/' . $book->getId(), [
             'auth_bearer' => $token,
             'json' => [
-                '@id' => '/books/' . $book->getId(),
-                // Must set all data because of standard PUT
-                'book' => 'https://gutendex.com/books/31547.json',
                 'condition' => BookCondition::DamagedCondition->value,
             ],
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -586,7 +585,7 @@ final class BookTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAdminUserICanDeleteABook(): void
     {
         $book = BookFactory::createOne(['title' => 'Hyperion']);

--- a/api/tests/Api/Admin/ReviewTest.php
+++ b/api/tests/Api/Admin/ReviewTest.php
@@ -16,6 +16,7 @@ use App\Tests\Api\Admin\Trait\UsersDataProviderTrait;
 use App\Tests\Api\Security\TokenGenerator;
 use App\Tests\Api\Trait\SerializerTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mercure\Update;
@@ -240,14 +241,14 @@ final class ReviewTest extends ApiTestCase
             'email' => UserFactory::createOneAdmin()->email,
         ]);
 
-        $this->client->request('PUT', '/admin/reviews/invalid', [
+        $this->client->request('PATCH', '/admin/reviews/invalid', [
             'auth_bearer' => $token,
             'json' => [
                 'body' => 'Very good book!',
                 'rating' => 5,
             ],
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -256,11 +257,15 @@ final class ReviewTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAdminUserICanUpdateAReview(): void
     {
         $book = BookFactory::createOne();
-        $review = ReviewFactory::createOne(['book' => $book]);
+        $review = ReviewFactory::createOne([
+            'book' => $book,
+            'body' => "Yeah, it's ok...",
+            'rating' => 3,
+        ]);
         $user = UserFactory::createOneAdmin();
         self::getMercureHub()->reset();
 
@@ -268,17 +273,14 @@ final class ReviewTest extends ApiTestCase
             'email' => $user->email,
         ]);
 
-        $response = $this->client->request('PUT', '/admin/reviews/' . $review->getId(), [
+        $response = $this->client->request('PATCH', '/admin/reviews/' . $review->getId(), [
             'auth_bearer' => $token,
             'json' => [
-                // Must set all data because of standard PUT
-                'book' => '/admin/books/' . $book->getId(),
-                'letter' => null,
                 'body' => 'Very good book!',
                 'rating' => 5,
             ],
             'headers' => [
-                'Content-Type' => 'application/ld+json',
+                'Content-Type' => 'application/merge-patch+json',
                 'Accept' => 'application/ld+json',
             ],
         ]);
@@ -351,7 +353,7 @@ final class ReviewTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAdminUserICanDeleteAReview(): void
     {
         $review = ReviewFactory::createOne(['body' => 'Best book ever!']);

--- a/api/tests/Api/BookmarkTest.php
+++ b/api/tests/Api/BookmarkTest.php
@@ -13,6 +13,7 @@ use App\Entity\Bookmark;
 use App\Repository\BookmarkRepository;
 use App\Tests\Api\Security\TokenGenerator;
 use App\Tests\Api\Trait\SerializerTrait;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mercure\Update;
@@ -140,7 +141,7 @@ final class BookmarkTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAUserICanCreateABookmark(): void
     {
         $book = BookFactory::createOne(['book' => 'https://openlibrary.org/books/OL2055137M.json']);
@@ -277,7 +278,7 @@ final class BookmarkTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAUserICanDeleteMyBookmark(): void
     {
         $book = BookFactory::createOne(['title' => 'Hyperion']);

--- a/api/tests/Api/ReviewTest.php
+++ b/api/tests/Api/ReviewTest.php
@@ -16,6 +16,7 @@ use App\Repository\ReviewRepository;
 use App\Tests\Api\Security\TokenGenerator;
 use App\Tests\Api\Trait\SerializerTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mercure\Update;
@@ -238,7 +239,7 @@ final class ReviewTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAUserICanAddAReviewOnABook(): void
     {
         $book = BookFactory::createOne();
@@ -443,7 +444,7 @@ final class ReviewTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAUserICanUpdateMyBookReview(): void
     {
         $review = ReviewFactory::createOne();
@@ -544,7 +545,7 @@ final class ReviewTest extends ApiTestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function asAUserICanDeleteMyBookReview(): void
     {
         $review = ReviewFactory::createOne(['body' => 'Best book ever!']);

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,11 +3,11 @@ services:
     image: ${IMAGES_PREFIX:-}app-php
     depends_on:
       database:
-        condition: service_healthy
+        condition: service_started
       pwa:
-        condition: service_healthy
+        condition: service_started
       keycloak:
-        condition: service_healthy
+        condition: service_started
     restart: unless-stopped
     environment:
       PWA_UPSTREAM: pwa:3000
@@ -124,7 +124,7 @@ services:
       retries: 15
     depends_on:
       keycloak-database:
-        condition: service_healthy
+        condition: service_started
     ports:
       - target: 8080
         published: 8080

--- a/pwa/components/admin/Admin.tsx
+++ b/pwa/components/admin/Admin.tsx
@@ -56,6 +56,7 @@ const AdminAdapter = ({
       fetchHydra(url, {
         ...options,
         headers: {
+          ...options.headers,
           Authorization: `Bearer ${session?.accessToken}`,
         },
       }),


### PR DESCRIPTION
Fixes #493

This was due to `standard_put`, following HTTP specification in API Platform.

PUT method was used for api-platform/admin compatibility, but now it supports PATCH: https://github.com/api-platform/admin/pull/589