### PR TITLE
Hydra docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
             url=$release-demo.api-platform.com
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
-          cors="https://$url|http://localhost|https://localhost|http://localhost:3000"
+          cors="https://$url|http://localhost|https://localhost|http://localhost:3000|https://api-platform.github.io"
           set -o pipefail
           helm upgrade $release ./helm/api-platform -f ./helm/api-platform/values.yaml \
             --install \

--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -8,9 +8,7 @@ doctrine:
 
         profiling_collect_backtrace: '%kernel.debug%'
     orm:
-        auto_generate_proxy_classes: true
         enable_native_lazy_objects: true
-        report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         identity_generation_preferences:

--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -8,6 +8,9 @@ doctrine:
 
         profiling_collect_backtrace: '%kernel.debug%'
     orm:
+        auto_generate_proxy_classes: true
+        enable_native_lazy_objects: true
+        report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         identity_generation_preferences:

--- a/api/src/Entity/Book.php
+++ b/api/src/Entity/Book.php
@@ -41,11 +41,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ApiResource(
     uriTemplate: '/admin/books{._format}',
+    shortName: 'AdminBook',
     types: [
         'https://schema.org/Book',
         'https://schema.org/Offer',
     ],
-    shortName: 'AdminBook',
     operations: [
         new GetCollection(
             paginationClientItemsPerPage: true,

--- a/api/src/Entity/Book.php
+++ b/api/src/Entity/Book.php
@@ -84,7 +84,6 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted("OIDC_ADMIN")',
 )]
 #[ApiResource(
-    shortName: 'Book',
     types: ['https://schema.org/Book', 'https://schema.org/Offer'],
     operations: [
         new GetCollection(

--- a/api/src/Entity/Book.php
+++ b/api/src/Entity/Book.php
@@ -45,6 +45,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         'https://schema.org/Book',
         'https://schema.org/Offer',
     ],
+    shortName: 'AdminBook',
     operations: [
         new GetCollection(
             paginationClientItemsPerPage: true,
@@ -83,6 +84,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted("OIDC_ADMIN")',
 )]
 #[ApiResource(
+    shortName: 'Book',
     types: ['https://schema.org/Book', 'https://schema.org/Offer'],
     operations: [
         new GetCollection(

--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -88,8 +88,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted("OIDC_ADMIN")',
 )]
 #[ApiResource(
-    shortName: 'Review',
     uriTemplate: '/books/{bookId}/reviews{._format}',
+    shortName: 'Review',
     types: ['https://schema.org/Review'],
     operations: [
         new GetCollection(

--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -89,7 +89,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 #[ApiResource(
     uriTemplate: '/books/{bookId}/reviews{._format}',
-    shortName: 'Review',
     types: ['https://schema.org/Review'],
     operations: [
         new GetCollection(

--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -38,6 +38,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @see https://schema.org/Review
  */
 #[ApiResource(
+    shortName: 'AdminReview',
     types: ['https://schema.org/Review'],
     operations: [
         new GetCollection(
@@ -87,6 +88,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted("OIDC_ADMIN")',
 )]
 #[ApiResource(
+    shortName: 'Review',
     uriTemplate: '/books/{bookId}/reviews{._format}',
     types: ['https://schema.org/Review'],
     operations: [

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -46,7 +46,6 @@ use Symfony\Component\Uid\Uuid;
     ]
 )]
 #[ApiResource(
-    shortName: 'User',
     types: ['https://schema.org/Person'],
     operations: [
         new Get(

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -25,6 +25,7 @@ use Symfony\Component\Uid\Uuid;
  * @see https://schema.org/Person
  */
 #[ApiResource(
+    shortName: 'AdminUser',
     types: ['https://schema.org/Person'],
     operations: [
         new GetCollection(
@@ -38,6 +39,16 @@ use Symfony\Component\Uid\Uuid;
             uriTemplate: '/admin/users/{id}{._format}',
             security: 'is_granted("OIDC_ADMIN")'
         ),
+    ],
+    normalizationContext: [
+        AbstractNormalizer::GROUPS => ['User:read'],
+        AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]
+)]
+#[ApiResource(
+    shortName: 'User',
+    types: ['https://schema.org/Person'],
+    operations: [
         new Get(
             uriTemplate: '/users/{id}{._format}',
             security: 'object === user'

--- a/api/tests/Api/Admin/schemas/Book/collection.json
+++ b/api/tests/Api/Admin/schemas/Book/collection.json
@@ -73,7 +73,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/Book$"
+            "pattern": "^/contexts/AdminBook$"
         },
         "@type": {
             "readOnly": true,

--- a/api/tests/Api/Admin/schemas/Book/item.json
+++ b/api/tests/Api/Admin/schemas/Book/item.json
@@ -6,7 +6,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/Book$"
+            "pattern": "^/contexts/AdminBook$"
         },
         "@type": {
             "readOnly": true,

--- a/api/tests/Api/Admin/schemas/Review/collection.json
+++ b/api/tests/Api/Admin/schemas/Review/collection.json
@@ -166,7 +166,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/Review$"
+            "pattern": "^/contexts/AdminReview$"
         },
         "@type": {
             "readOnly": true,

--- a/api/tests/Api/Admin/schemas/Review/item.json
+++ b/api/tests/Api/Admin/schemas/Review/item.json
@@ -6,7 +6,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/Review$"
+            "pattern": "^/contexts/AdminReview$"
         },
         "@id": {
             "readOnly": true,

--- a/api/tests/Api/Admin/schemas/User/collection.json
+++ b/api/tests/Api/Admin/schemas/User/collection.json
@@ -52,7 +52,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/User$"
+            "pattern": "^/contexts/AdminUser$"
         },
         "@type": {
             "readOnly": true,

--- a/api/tests/Api/Admin/schemas/User/item.json
+++ b/api/tests/Api/Admin/schemas/User/item.json
@@ -6,7 +6,7 @@
         "@context": {
             "readOnly": true,
             "type": "string",
-            "pattern": "^/contexts/User$"
+            "pattern": "^/contexts/AdminUser$"
         },
         "@id": {
             "readOnly": true,


### PR DESCRIPTION
| Q             | A
  | ------------- | ---
  | Branch?       | main
  | Tickets       | Related to api-platform/core#7746
  | License       | MIT

This PR demonstrates an issue and potential solution when using multiple `#[ApiResource]` attributes on a single entity with different URI templates.

When a resource class has multiple `#[ApiResource]` declarations with different URI templates (e.g., `/admin/multi_route_books` and `/multi_route_books`), the  client generator only generates types for the resource that appears in the JSON-LD entrypoint, typically missing the other routes.

Example:

```php
  #[ApiResource(uriTemplate: '/admin/multi_route_books')]
  #[ApiResource(uriTemplate: '/multi_route_books')]
  class MultipleResourceBook
 ```
 
 Using 2 different shortName will do the trick, https://github.com/api-platform/core/pull/7746 will fix the behavior (as without the patch this won't work). 
 
 We'll also add an automatic way of handling this inside API Platform so this PR may not be needed in the end (for now its just a showcase).
 
 We also need to test that @api-platform/admin is still working.
