### PR TITLE
ci: update aquasecurity/trivy-action tag from 0.35.0 to v0.35.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-trivy-
       -
         name: Run Trivy Vulnerability Scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: 'europe-west1-docker.pkg.dev/${{ secrets.GKE_PROJECT }}/${{ secrets.GKE_PROJECT }}/${{ matrix.image }}:latest'
           exit-code: '1'


### PR DESCRIPTION
## Summary

- Updates `aquasecurity/trivy-action` tag from `0.35.0` to `v0.35.0` in `.github/workflows/security.yml`

Following a supply chain security incident on the `tj-actions/changed-files` ecosystem, `aquasecurity` migrated all their tags to use the `v` prefix convention (e.g. `v0.35.0` instead of `0.35.0`). All other GitHub Actions in this project already use the latest version (either via floating major tags or exact pinned versions).

## Test plan

- [ ] Verify the `Docker Scan` workflow runs successfully with the updated tag

Generated with [Claude Code](https://claude.ai/code)