### PR TITLE
ci: authenticate upgrade workflow via GitHub App token

### DIFF
--- a/.github/workflows/upgrade-api-platform.yml
+++ b/.github/workflows/upgrade-api-platform.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 1484548 # API Platform release manager
+          private-key: ${{ secrets.RELEASE_MANAGER_APP_PRIVATE_KEY }}
+      -
         name: Checkout
         uses: actions/checkout@v6
       -
@@ -57,7 +64,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         if: steps.diff.outputs.to-version != ''
         with:
-          token: ${{ secrets.API_PLATFORM_DEMO_PR_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: release/api-platform-${{ steps.diff.outputs.to-version }}
           base: ${{ github.event.repository.default_branch }}
           commit-message: "chore: upgrade API Platform to ${{ steps.diff.outputs.to-version }}"


### PR DESCRIPTION
## Problème

Le workflow `Upgrade API Platform` plante à l'étape `Create Pull Request` (run [26624418740](https://github.com/api-platform/demo/actions/runs/26624418740/job/78460206097)) :

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Le secret `API_PLATFORM_DEMO_PR_TOKEN` (un PAT perso, posé en 2024-10) n'est plus accepté par GitHub : il fonctionnait encore le 22/05 (PR #641 créée par le workflow) et était rejeté le 29/05. Un remplacement par un fine-grained PAT bute sur l'approbation org (`Resource not accessible by personal access token`).

## Correctif

Génère un token éphémère depuis la GitHub App **API Platform release manager** (déjà utilisée pour déclencher ce workflow, et qui a `contents: write` + `pull_requests: write` sur `demo`) via `actions/create-github-app-token`, au lieu du PAT.

Avantages : token regénéré et valable 1h à chaque run (plus d'expiration silencieuse), non lié à un compte perso, pas d'approbation de PAT côté org.

## Prérequis avant merge / run

- [ ] Un **owner** de l'org génère une clé privée pour l'App et la stocke dans le secret repo `RELEASE_MANAGER_APP_PRIVATE_KEY`.
- [ ] Le secret `API_PLATFORM_DEMO_PR_TOKEN` peut ensuite être supprimé.

L'App ID `1484548` est public, codé en dur dans le workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)