### PR TITLE
fix(helm): remove wildcard redirect URIs

### DIFF
--- a/helm/api-platform/keycloak/config/realm-demo.json
+++ b/helm/api-platform/keycloak/config/realm-demo.json
@@ -519,16 +519,16 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "sEocbxCy7iFS8NzYzWyQ71QgxTDZ9fnU",
-      "redirectUris": [
-        "/*"
-      ],
+      "redirectUris": [],
       "webOrigins": [
-        "/*"
+        "https://localhost",
+        "http://localhost:3000",
+        "https://app-host.invalid"
       ],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,
-      "standardFlowEnabled": true,
+      "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": true,
@@ -608,10 +608,14 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "*"
+        "https://localhost/api/auth/oauth2/callback/keycloak",
+        "http://localhost:3000/api/auth/oauth2/callback/keycloak",
+        "https://app-host.invalid/api/auth/oauth2/callback/keycloak"
       ],
       "webOrigins": [
-        "*"
+        "https://localhost",
+        "http://localhost:3000",
+        "https://app-host.invalid"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -631,7 +635,9 @@
         "frontchannel.logout.session.required": "true",
         "oauth2.device.authorization.grant.enabled": "false",
         "display.on.consent.screen": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "https://localhost/*##http://localhost:3000/*##https://app-host.invalid/*"
       },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
@@ -666,10 +672,12 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "*"
+        "https://localhost/bundles/apiplatform/swagger-ui/oauth2-redirect.html",
+        "https://app-host.invalid/bundles/apiplatform/swagger-ui/oauth2-redirect.html"
       ],
       "webOrigins": [
-        "*"
+        "https://localhost",
+        "https://app-host.invalid"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -687,7 +695,8 @@
         "backchannel.logout.session.required": "true",
         "standard.token.exchange.enabled": "false",
         "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,

--- a/helm/api-platform/templates/configmap.yaml
+++ b/helm/api-platform/templates/configmap.yaml
@@ -37,5 +37,8 @@ metadata:
   labels:
     {{- include "api-platform.labelsKeycloak" . | nindent 4 }}
 data:
-{{ (.Files.Glob .Values.keycloak.importRealm.path).AsConfig | indent 2 }}
+{{/* Keycloak rejects wildcards in the host part of a redirect URI, and the deployed host is
+     dynamic (pr-<N>-demo.api-platform.com). The realm file therefore ships the unresolvable
+     app-host.invalid placeholder, swapped here for the host this release is served on. */}}
+{{ (.Files.Glob .Values.keycloak.importRealm.path).AsConfig | replace "app-host.invalid" (first .Values.ingress.hosts).host | indent 2 }}
 {{- end }}


### PR DESCRIPTION
## Summary

Fixes the private advisory **GHSA-2rmv-4743-38c6** (High, CVSS 8.1, CWE-601).

`realm-demo.json` shipped `redirectUris: ["*"]` and `webOrigins: ["*"]` on `api-platform-pwa` (confidential, BFF, standard flow) **and** on `api-platform-swagger` — a **public** client, so no secret is even needed to exchange a stolen code. A victim completing the login flow had a live authorization code delivered to an attacker-controlled origin, exchangeable for a real `access_token`/`id_token`.

**The Keycloak upgrade merged in #679 does not close this.** Measured against the deployed `pr-679` environment, running the upgraded Keycloak 26.6.4:

```
$ curl -o /dev/null -w '%{http_code}' \
    'https://pr-679-demo.api-platform.com/oidc/realms/demo/protocol/openid-connect/auth?client_id=api-platform-pwa&redirect_uri=https://attacker.evil.example/callback&response_type=code&scope=openid'
200
```

while the properly scoped built-in `account` client answers `400 Invalid parameter: redirect_uri` on the same server. Redirect validation is active; the wildcard is what bypasses it. This PR is the actual remediation.

## Changes

Every `api-platform-*` client now lists explicit redirect URIs and web origins:

| client | redirect URIs | notes |
| --- | --- | --- |
| `api-platform-pwa` | the better-auth callback only | PKCE `S256` enforced, explicit `post.logout.redirect.uris` |
| `api-platform-swagger` | the Swagger UI `oauth2-redirect.html` asset only | PKCE `S256` enforced |
| `api-platform-api` | none, `standardFlowEnabled: false` | resource server, never runs a browser flow |

`post.logout.redirect.uris` is required, not decorative: without it Keycloak falls back to the redirect URIs, and `/api/auth/keycloak-logout` redirects to `/books`, which would then be rejected. The `##` separator is Keycloak's `Constants.CFG_DELIMITER`.

PKCE enforcement is safe on both: better-auth already sends `code_challenge_method=S256` (`@better-auth/core/dist/oauth2/create-authorization-url.mjs`), and `api_platform.oauth.pkce` is already enabled while Swagger UI only implements S256.

## Dynamic host

Keycloak accepts no wildcard in the host part of a redirect URI, while the deployed host is dynamic (`pr-<N>-demo.api-platform.com`). The realm ships the `app-host.invalid` placeholder and the Helm ConfigMap swaps it for the release host, reusing the `(first .Values.ingress.hosts).host` that already drives `oidc-server-url` in the same ConfigMap — so `deploy.yml` needs no change. `.invalid` is reserved by RFC 2606, so the entry left over in local development is unresolvable and cannot leak a code.

`localhost` is kept on purpose: `e2e/playwright.config.js` uses `baseURL: 'https://localhost'` and the E2E job runs against it. `api-platform.github.io` is left exactly where it is — the `cors` list of `deploy.yml`, feeding `php.corsAllowOrigin` and `mercure.extraDirectives`, both untouched. No OIDC flow originates from that origin, so it gets no Keycloak entry; adding `https://api-platform.github.io` to the Swagger client's `webOrigins` is a one-liner if the Hydra console ever needs a token.

## Points worth discussing

- **`api-platform-api` loses `standardFlowEnabled`.** It only serves as the `uma-ticket` audience and as `OIDC_AUD`; no browser flow uses it. If anything regresses, restoring `standardFlowEnabled: true` while keeping `redirectUris: []` is enough.
- **The Swagger redirect URI hardcodes an API Platform asset path** (`/bundles/apiplatform/swagger-ui/oauth2-redirect.html`, from `SwaggerUi/index.html.twig`). If a future upgrade moves that asset, *Authorize* on `/docs` breaks silently — worth adding to the upgrade checklist.
- **`app-host.invalid` vs templating the realm.** The alternatives were `tpl` on the whole file or keycloak-config-cli variable substitution; the placeholder keeps `realm-demo.json` valid JSON for the raw `--import-realm` that compose uses, which the other options do not.

## Verification

**Exploit closed** — the negative control of the advisory PoC fails for all three clients:

```
api-platform-pwa         -> 400  Invalid parameter: redirect_uri
api-platform-swagger     -> 400  Invalid parameter: redirect_uri
api-platform-api         -> 400  Invalid parameter: redirect_uri
```

A legitimate redirect URI is accepted, and PKCE enforcement is observable: omitting `code_challenge_method` yields `error=invalid_request&error_description=Missing+parameter:+code_challenge_method`.

**Suites** (realm reimported from scratch on Keycloak 26.6.4, `@read` and `@write` each on a fresh stack as CI does):

- Playwright `@read`: 24 passed / 2 flaky · `@write`: 8 passed / 3 flaky / 0 failed. Same flaky set as before — login-page timing, green on retry.
- PHPUnit 126 tests / 576 assertions OK · PHPStan · Rector · `doctrine:schema:validate` · `redocly lint` · php-cs-fixer all clean.
- `helm lint`, and `helm template --set ingress.hosts[0].host=pr-676-demo.api-platform.com` leaves no `app-host.invalid` while rendering both the PWA callback and the Swagger UI redirect for that host.

## Follow-up

Adding the `deploy` label exercises the dynamic-host substitution on a real `pr-<N>-demo.api-platform.com` before merging.
