### PR TITLE
ci: replace archived grafana/k6-action with setup-k6-action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,10 +20,10 @@ jobs:
         name: Checkout
         uses: actions/checkout@v7
       -
+        name: Setup k6
+        uses: grafana/setup-k6-action@v1.2.1
+      -
         name: Run local k6 test
-        uses: grafana/k6-action@v0.3.1
-        with:
-          filename: k6/script.js
-          flags: --out json=results.json
+        run: k6 run k6/script.js --out json=results.json
         env:
           TARGET: ${{ inputs.url }}


### PR DESCRIPTION
> Kept as a dedicated PR for SRE review, since `check.yml` is the post-deploy gate.

## Summary

`grafana/k6-action@v0.3.1` is **archived** upstream. The official replacement, `grafana/setup-k6-action`, only *installs* k6 (`inputs`: `k6-version`, `browser`, `github-token`), so the run step becomes explicit.

`k6/script.js` already reads `__ENV.TARGET`: the script is untouched and the thresholds (`http_req_duration p(95)<5000`, `http_req_failed rate<0.01`, `checks rate>0.95`) are unchanged.

## Points for review

- **`k6-version` is left unset**, so the action installs its own default. Pin it if the SRE team wants a reproducible k6 version across runs.
- **`results.json` is still not kept.** It is written by `--out json=results.json` and then discarded with the runner. Now that the run step is explicit, adding an `actions/upload-artifact` step is trivial — say the word and I will include it.
- **This cannot be validated from a PR CI run.** `check.yml` is a `workflow_call` invoked only after a deployment (`cd.yml`, `needs: [deploy]`). The only way to exercise it is a feature deploy: add the `deploy` label to this PR to trigger `build → deploy → check` against `pr-<N>-demo.api-platform.com`.

## Verification

- YAML parses, and the workflow structure is unchanged apart from the split into setup + run.
- The untrusted-ish `inputs.url` still reaches k6 through `env:` and never through the `run:` command line, which stays a fixed literal — no workflow injection surface added.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)